### PR TITLE
Add OSys.argv to retrieve the command line arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ test: build
 	sh test.sh TestPervasives
 	sh test.sh TestExtraction
 	sh test.sh RunIO -n
+	sh test.sh Argv
 
 # With installed library (check proper installation)
 install-test: build

--- a/src/IO_Sys.v
+++ b/src/IO_Sys.v
@@ -44,11 +44,14 @@ Parameter getenv_opt: ocaml_string -> IO (option ocaml_string).
     since the beginning of execution. *)
 Parameter time : IO float.
 
+Parameter argv : IO (list ocaml_string).
+
 (** ** Extraction *)
 
 Extract Constant command    => "fun c k -> k (Sys.command    c)".
 Extract Constant getenv     => "fun e k -> k (Sys.getenv     e)".
 Extract Constant getenv_opt => "fun e k -> k (Sys.getenv_opt e)".
 Extract Constant time       => "fun   k -> k (Sys.time      ())".
+Extract Constant argv       => "fun   k -> k (Array.to_list (Sys.argv))".
 
 End OSys.

--- a/test/Argv.v
+++ b/test/Argv.v
@@ -1,0 +1,21 @@
+From Coq Require Import
+     extraction.ExtrOcamlIntConv.
+
+From SimpleIO Require Import
+  SimpleIO
+  IO_Sys.
+Import IO.Notations.
+
+(* begin hide *)
+Set Warnings "-extraction-opaque-accessed,-extraction".
+(* end hide *)
+
+(* This test returns the number of arguments on the command line *)
+
+Definition f : IO unit :=
+  args <- OSys.argv ;;
+  print_int (int_of_nat (length args)).
+
+Definition y0 : io_unit := IO.unsafe_run f.
+
+Separate Extraction y0.


### PR DESCRIPTION
The following patch adds a binding to Ocaml Sys.argv, and a corresponding test.

Tested using 8.14.0. Test output is 

```
Finished, 19 targets (1 cached) in 00:00:00.
1%         
```
