### PR TITLE
Update Dune

### DIFF
--- a/coq-simple-io.opam
+++ b/coq-simple-io.opam
@@ -17,13 +17,14 @@ license: "MIT"
 homepage: "https://github.com/Lysxia/coq-simple-io"
 bug-reports: "https://github.com/Lysxia/coq-simple-io/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
   "ocamlfind"
   "coq" {>= "8.11~"}
   "coq-ext-lib" {>= "0.10.0"}
   "ocamlbuild" {with-test & >= "0.9.0"}
   "cppo" {build & >= "1.6.8"}
+  "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/Lysxia/coq-simple-io.git"
 build: [

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.5)
+(lang dune 2.8)
 (using coq 0.2)
 (using menhir 2.0)
 (name coq-simple-io)


### PR DESCRIPTION
https://github.com/coq/ceps/blob/master/text/048-packaging-coq-native.md#note-to-library-developers-and-package-maintainers
> - for `dune / coq.theory`: this will require Coq 8.12.1+ and a version of `dune` implementing [PR ocaml/dune#3210](https://github.com/ocaml/dune/pull/3210) (cf. [this comment](https://github.com/coq/ceps/pull/48#issuecomment-727020253) by **@ejgallego**); otherwise (without native support), Dune will just ignore the native parts and no `./coq-native/*.cmxs` file will be installed.