### PR TITLE
Do not use V variable prepended in cppo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ COQ_VERSION:=$(word 1, $(shell coqc -print-version))
 OCAML_VERSION:=$(shell ocamlc -version)
 
 %: %.cppo
-	$(V)cppo -V COQ:$(COQ_VERSION) -V OCAML:$(OCAML_VERSION) -n -o $@ $^
+	cppo -V COQ:$(COQ_VERSION) -V OCAML:$(OCAML_VERSION) -n -o $@ $^
 
 test:
 	sh ./testall.sh


### PR DESCRIPTION
In some builders, such as Ubuntu ones, the V variable is exported with "1" value (such as enable verbose builds for many build systems)

This results in:
   dh_auto_build
	make -j4 "INSTALL=install --strip-program=true"
make[1]: Entering directory '/<<PKGBUILDDIR>>'
1cppo -V COQ:8.15.2 -V OCAML:4.13.1 -n -o _CoqProject _CoqProject.cppo make[1]: 1cppo: No such file or directory

Fixes issue: #57