### PR TITLE
Update dune config

### DIFF
--- a/coq-simple-io.opam
+++ b/coq-simple-io.opam
@@ -17,7 +17,7 @@ license: "MIT"
 homepage: "https://github.com/Lysxia/coq-simple-io"
 bug-reports: "https://github.com/Lysxia/coq-simple-io/issues"
 depends: [
-  "dune" {>= "2.8"}
+  "dune" {>= "3.7"}
   "ocaml" {>= "4.08.0"}
   "ocamlfind"
   "coq" {>= "8.11~"}

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
-(lang dune 2.8)
-(using coq 0.3)
+(lang dune 3.7)
+(using coq 0.7)
 (using menhir 2.0)
 (name coq-simple-io)
 (version dev)

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (coq.theory
  (name SimpleIO)
  (package coq-simple-io)
- (libraries coq-simple-io.plugin))
+ (plugins coq-simple-io.plugin))
 
 (rule
   (alias compat)


### PR DESCRIPTION
(coq ...) versions earlier than 0.7 disabled native compilation. We don't want that (caught in Coq CI).