### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/src/IO_String.v.cppo
+++ b/src/IO_String.v.cppo
@@ -12,7 +12,7 @@
 From Coq Require Import
      Strings.String
      Strings.Ascii
-     extraction.ExtrOcamlIntConv.
+     ExtrOcamlIntConv.
 
 From SimpleIO Require Import
      IO_Stdlib.


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.