### PR TITLE
Add mode to forward stdin and stdout to RunIO scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,29 @@ Definition main : IO unit :=
 RunIO main.
 ```
 
+### Run as a command-line script
+
+You can run a `.v` file from the command line with `coqc`.
+To forward stdin and stdout to your `RunIO` scripts,
+set the option `RunIO IOMode Forward`.
+
+```coq
+From SimpleIO Require Import SimpleIO.
+Import IO.Notations.
+
+RunIO IOMode Forward.
+
+Definition cat : IO unit :=
+  _ <- catch_eof
+    (IO.fix_io (fun f _ =>
+      input <- read_line ;;
+      print_endline input ;;
+      f tt :> IO unit) tt) ;;
+  IO.ret tt.
+
+RunIO cat.
+```
+
 ### Configuration
 
 ```coq
@@ -162,6 +185,11 @@ RunIO Include "my-directory".
 RunIO Smart On.
 RunIO Smart Off.
 ```
+
+New `RunIO` options may be added in the future.
+To avoid risks of future collisions with the main `RunIO` command,
+use names with a lower case initial (like `RunIO main`),
+or put the action name in parentheses (like `RunIO (Builder)` to run the `IO` action `Builder`).
 
 ## Library organization
 

--- a/plugin/coqsimpleio.mlg.cppo
+++ b/plugin/coqsimpleio.mlg.cppo
@@ -13,8 +13,8 @@ let run c =
 #else
   let opaque_access = () in
 #endif
-  Feedback.msg_info (Pp.str ("Running " ^ string_of_constr_expr c ^ " ..."));
-  run ~plugin_name:"coq_simple_io" ~opaque_access
+  let name = string_of_constr_expr c in
+  run ~plugin_name:"coq_simple_io" ~opaque_access ~name
     (CAst.make @@ apply_constr run_ast [c])
 
 let string_unopt = function
@@ -37,4 +37,6 @@ VERNAC COMMAND EXTEND RunIO CLASSIFIED AS SIDEFF
   | ["RunIO" "Smart" "On"] -> { smart_mode := true }
   | ["RunIO" "Smart" "Off"] -> { smart_mode := false }
   | ["RunIO" "Reset"] -> { IOLib.reset () }
+  | ["RunIO" "IOMode" "Repl"] -> { io_mode := Repl }
+  | ["RunIO" "IOMode" "Forward"] -> { io_mode := Forward }
 END

--- a/plugin/iOLib.mli
+++ b/plugin/iOLib.mli
@@ -13,6 +13,18 @@ val add_module_to_open : string -> unit
 (* Automatically insert common dependencies (zarith, coq-simple-io.extraction).
    [true] by default. *)
 val smart_mode : bool ref
+
+(** Option for handling standard input and output *)
+type io_mode
+  = Repl
+  (** Default mode compatible with interactive Coq sessions *)
+  | Forward
+  (** Forward stdin,stdout,stderr to the child processes running the extracted
+      programs. This option lets you run [RunIO] scripts from the command line. *)
+
+(** See [type io_mode] above. *)
+val io_mode : io_mode ref
+
 val reset : unit -> unit
 
 val apply_constr : constr_expr -> constr_expr list -> constr_expr_r
@@ -20,4 +32,4 @@ val mk_ref : string -> constr_expr
 val string_of_constr_expr : constr_expr -> string
 val define_and_run : plugin_name:string -> opaque_access:Compat.indirect_accessor ->
   Environ.env -> Evd.evar_map -> Evd.econstr -> unit
-val run : plugin_name:string -> opaque_access:Compat.indirect_accessor -> constr_expr -> unit
+val run : plugin_name:string -> opaque_access:Compat.indirect_accessor -> name:string -> constr_expr -> unit

--- a/test/argv/dune
+++ b/test/argv/dune
@@ -7,7 +7,3 @@
 (test
  (name main)
  (flags :standard -w -33-39-67))
-
-(rule
- (alias runtest)
- (action (diff main.expected main.output)))

--- a/test/example/dune
+++ b/test/example/dune
@@ -7,7 +7,3 @@
 (test
  (name main)
  (flags :standard -w -33-39-67))
-
-(rule
- (alias runtest)
- (action (diff main.expected main.output)))

--- a/test/extraction/dune
+++ b/test/extraction/dune
@@ -9,7 +9,3 @@
  (name main)
  (libraries unix)
  (flags :standard -w -33-39-67))
-
-(rule
- (alias runtest)
- (action (diff main.expected main.output)))

--- a/test/forward/dune
+++ b/test/forward/dune
@@ -1,0 +1,11 @@
+(rule
+ (alias runtest)
+ (action (diff main.expected main.output)))
+
+(rule
+ (deps (package coq-simple-io))
+ (action
+  (with-stdout-to main.output
+   (pipe-stdout
+    (run echo "this is\na test")
+    (run %{bin:coqc} -I ../../plugin -Q ../../src SimpleIO %{dep:main.v})))))

--- a/test/forward/main.expected
+++ b/test/forward/main.expected
@@ -1,0 +1,2 @@
+this is
+a test

--- a/test/forward/main.v
+++ b/test/forward/main.v
@@ -1,0 +1,14 @@
+From SimpleIO Require Import SimpleIO.
+Import IO.Notations.
+
+RunIO IOMode Forward.
+
+Definition cat : IO unit :=
+  _ <- catch_eof
+    (IO.fix_io (fun f _ =>
+      input <- read_line ;;
+      print_endline input ;;
+      f tt :> IO unit) tt) ;;
+  IO.ret tt.
+
+RunIO cat.

--- a/test/pervasives/dune
+++ b/test/pervasives/dune
@@ -7,7 +7,3 @@
 (test
  (name main)
  (flags :standard -w -33-39-67))
-
-(rule
- (alias runtest)
- (action (diff main.expected main.output)))


### PR DESCRIPTION
Close #76

```coq
(* cat.v *)
From SimpleIO Require Import SimpleIO.
Import IO.Notations.
RunIO IOMode Forward.
Definition cat : IO unit :=
  _ <- catch_eof
    (IO.fix_io (fun f _ =>
      input <- read_line ;;
      print_endline input ;;
      f tt :> IO unit) tt) ;;
  IO.ret tt.
RunIO cat.
```

```
echo "foo" | coqc cat.v
```

cc @zacque0